### PR TITLE
fix: resolve reverse task artifacts from package root

### DIFF
--- a/src/reverse/ReverseTaskStore.ts
+++ b/src/reverse/ReverseTaskStore.ts
@@ -4,8 +4,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import {existsSync} from 'node:fs';
 import {appendFile, mkdir, readFile, stat, writeFile} from 'node:fs/promises';
 import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import type {
   ReverseTaskDescriptor,
@@ -73,11 +75,36 @@ async function shouldResetPlaceholderJsonl(targetPath: string): Promise<boolean>
   }
 }
 
+function findPackageRoot(fromDir: string): string | undefined {
+  let currentDir = fromDir;
+
+  while (true) {
+    if (existsSync(path.join(currentDir, 'package.json'))) {
+      return currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+    currentDir = parentDir;
+  }
+}
+
+function resolveDefaultTaskRootDir(): string {
+  const packageRoot = findPackageRoot(path.dirname(fileURLToPath(import.meta.url)));
+  if (packageRoot) {
+    return path.join(packageRoot, 'artifacts', 'tasks');
+  }
+
+  return path.join(process.cwd(), 'artifacts', 'tasks');
+}
+
 export class ReverseTaskStore implements ReverseTaskReadApi {
   readonly rootDir: string;
 
   constructor(options: ReverseTaskStoreOptions = {}) {
-    this.rootDir = options.rootDir ?? path.join(process.cwd(), 'artifacts', 'tasks');
+    this.rootDir = options.rootDir ?? resolveDefaultTaskRootDir();
   }
 
   async openTask(input: ReverseTaskOpenInput): Promise<ReverseTaskHandle> {

--- a/tests/unit/reverse/ReverseTaskStore.test.ts
+++ b/tests/unit/reverse/ReverseTaskStore.test.ts
@@ -5,14 +5,49 @@
  */
 
 import assert from 'node:assert';
+import {existsSync} from 'node:fs';
 import {mkdtemp, readFile, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import path from 'node:path';
 import {describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
 
 import {ReverseTaskStore} from '../../../src/reverse/ReverseTaskStore.js';
 
+function findPackageRoot(fromDir: string): string {
+  let currentDir = fromDir;
+
+  while (true) {
+    if (existsSync(path.join(currentDir, 'package.json'))) {
+      return currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error(`Unable to find package.json from ${fromDir}`);
+    }
+    currentDir = parentDir;
+  }
+}
+
 describe('ReverseTaskStore', () => {
+  it('resolves the default task root from the package root instead of process cwd', () => {
+    const originalCwd = process.cwd;
+    const fakeCwd = path.join(path.parse(process.cwd()).root, 'Windows', 'system32');
+    const repoRoot = findPackageRoot(path.dirname(fileURLToPath(import.meta.url)));
+
+    process.cwd = () => fakeCwd;
+
+    try {
+      const store = new ReverseTaskStore();
+
+      assert.strictEqual(store.rootDir, path.join(repoRoot, 'artifacts', 'tasks'));
+      assert.notStrictEqual(store.rootDir, path.join(fakeCwd, 'artifacts', 'tasks'));
+    } finally {
+      process.cwd = originalCwd;
+    }
+  });
+
   it('creates and reopens a reverse task with durable JSON and JSONL artifacts', async () => {
     const rootDir = await mkdtemp(path.join(tmpdir(), 'js-reverse-task-store-'));
 


### PR DESCRIPTION
## Summary
- resolve `ReverseTaskStore` default artifacts path from the nearest package root instead of `process.cwd()`
- keep a `process.cwd()` fallback only when no package root can be found
- add a regression test covering Windows `system32` cwd drift

## Test Plan
- npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test build/tests/unit/reverse/ReverseTaskStore.test.js build/tests/unit/tools/rebuild.test.js

Closes #6
