### PR TITLE
fix: resolve runtime defaults from package root

### DIFF
--- a/src/modules/collector/CodeCache.ts
+++ b/src/modules/collector/CodeCache.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import crypto from 'crypto';
 import { logger } from '../../utils/logger.js';
 import type { CodeFile, CollectCodeResult } from '../../types/index.js';
+import { resolveDefaultCodeCacheDir } from '../../utils/projectPaths.js';
 
 export interface CacheEntry {
   url: string;
@@ -33,7 +34,7 @@ export class CodeCache {
   private readonly MAX_MEMORY_CACHE_SIZE = 100; // 最多 100 个条目
 
   constructor(options: CacheOptions = {}) {
-    this.cacheDir = options.cacheDir || path.join(process.cwd(), '.cache', 'code');
+    this.cacheDir = options.cacheDir || resolveDefaultCodeCacheDir(import.meta.url);
     this.maxAge = options.maxAge || 24 * 60 * 60 * 1000; // 默认24小时
     this.maxSize = options.maxSize || 100 * 1024 * 1024; // 默认100MB
   }
@@ -276,4 +277,3 @@ export class CodeCache {
     logger.info('Cache warmup completed');
   }
 }
-

--- a/src/modules/debugger/DebuggerManager.ts
+++ b/src/modules/debugger/DebuggerManager.ts
@@ -29,6 +29,7 @@ import { WatchExpressionManager } from './WatchExpressionManager.js';
 import { XHRBreakpointManager } from './XHRBreakpointManager.js';
 import { EventBreakpointManager } from './EventBreakpointManager.js';
 import { BlackboxManager } from './BlackboxManager.js';
+import { resolveDefaultDebuggerSessionsDir } from '../../utils/projectPaths.js';
 
 /**
  * 断点信息
@@ -122,6 +123,10 @@ export class DebuggerManager {
   private breakpointResolvedListener: ((params: any) => void) | null = null;
 
   constructor(private collector: CodeCollector) {}
+
+  private getDefaultSessionsDir(): string {
+    return resolveDefaultDebuggerSessionsDir(import.meta.url);
+  }
 
   /**
    * 🆕 获取共享的 CDP Session（供子管理器使用）
@@ -1068,7 +1073,7 @@ export class DebuggerManager {
 
     // 如果未指定路径，使用默认路径
     if (!filePath) {
-      const sessionsDir = path.join(process.cwd(), 'debugger-sessions');
+      const sessionsDir = this.getDefaultSessionsDir();
       await fs.mkdir(sessionsDir, { recursive: true });
       filePath = path.join(sessionsDir, `session-${Date.now()}.json`);
     } else {
@@ -1182,7 +1187,7 @@ export class DebuggerManager {
    * 列出所有已保存的会话文件
    */
   async listSavedSessions(): Promise<Array<{ path: string; timestamp: number; metadata?: any }>> {
-    const sessionsDir = path.join(process.cwd(), 'debugger-sessions');
+    const sessionsDir = this.getDefaultSessionsDir();
 
     try {
       await fs.access(sessionsDir);

--- a/src/reverse/ReverseTaskStore.ts
+++ b/src/reverse/ReverseTaskStore.ts
@@ -4,10 +4,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import {existsSync} from 'node:fs';
 import {appendFile, mkdir, readFile, stat, writeFile} from 'node:fs/promises';
 import path from 'node:path';
-import {fileURLToPath} from 'node:url';
 
 import type {
   ReverseTaskDescriptor,
@@ -17,6 +15,7 @@ import type {
   ReverseTaskReadApi,
   ReverseTaskStoreOptions,
 } from '../types/index.js';
+import {resolveDefaultArtifactsTasksDir} from '../utils/projectPaths.js';
 
 function nowTimestamp(): number {
   return Date.now();
@@ -75,29 +74,8 @@ async function shouldResetPlaceholderJsonl(targetPath: string): Promise<boolean>
   }
 }
 
-function findPackageRoot(fromDir: string): string | undefined {
-  let currentDir = fromDir;
-
-  while (true) {
-    if (existsSync(path.join(currentDir, 'package.json'))) {
-      return currentDir;
-    }
-
-    const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) {
-      return undefined;
-    }
-    currentDir = parentDir;
-  }
-}
-
 function resolveDefaultTaskRootDir(): string {
-  const packageRoot = findPackageRoot(path.dirname(fileURLToPath(import.meta.url)));
-  if (packageRoot) {
-    return path.join(packageRoot, 'artifacts', 'tasks');
-  }
-
-  return path.join(process.cwd(), 'artifacts', 'tasks');
+  return resolveDefaultArtifactsTasksDir(import.meta.url);
 }
 
 export class ReverseTaskStore implements ReverseTaskReadApi {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,14 +5,14 @@
 
 import { config as dotenvConfig } from 'dotenv';
 import { existsSync } from 'fs';
-import { resolve } from 'path';
 import { AIService } from '../services/AIService.js';
 import { OpenAIProvider } from '../services/OpenAIProvider.js';
 import { AnthropicProvider } from '../services/AnthropicProvider.js';
 import { GeminiProvider } from '../services/GeminiProvider.js';
+import { resolveDefaultEnvPath } from './projectPaths.js';
 
 // Load .env file if it exists
-const envPath = resolve(process.cwd(), '.env');
+const envPath = resolveDefaultEnvPath(import.meta.url);
 if (existsSync(envPath)) {
   dotenvConfig({ path: envPath });
 }

--- a/src/utils/projectPaths.ts
+++ b/src/utils/projectPaths.ts
@@ -1,0 +1,45 @@
+/**
+ * Runtime path helpers that stay stable even when the host launches the
+ * server with an unexpected working directory (for example Windows system32).
+ */
+
+import {existsSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+function findPackageRoot(fromDir: string): string | undefined {
+  let currentDir = fromDir;
+
+  while (true) {
+    if (existsSync(path.join(currentDir, 'package.json'))) {
+      return currentDir;
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      return undefined;
+    }
+    currentDir = parentDir;
+  }
+}
+
+export function resolvePackageRoot(moduleUrl: string): string {
+  const packageRoot = findPackageRoot(path.dirname(fileURLToPath(moduleUrl)));
+  return packageRoot ?? process.cwd();
+}
+
+export function resolveDefaultArtifactsTasksDir(moduleUrl: string): string {
+  return path.join(resolvePackageRoot(moduleUrl), 'artifacts', 'tasks');
+}
+
+export function resolveDefaultDebuggerSessionsDir(moduleUrl: string): string {
+  return path.join(resolvePackageRoot(moduleUrl), 'debugger-sessions');
+}
+
+export function resolveDefaultCodeCacheDir(moduleUrl: string): string {
+  return path.join(resolvePackageRoot(moduleUrl), '.cache', 'code');
+}
+
+export function resolveDefaultEnvPath(moduleUrl: string): string {
+  return path.join(resolvePackageRoot(moduleUrl), '.env');
+}

--- a/tests/unit/cache/CodeCacheCompressor.test.ts
+++ b/tests/unit/cache/CodeCacheCompressor.test.ts
@@ -6,6 +6,7 @@
  */
 import assert from 'node:assert';
 import {describe, it} from 'node:test';
+import path from 'node:path';
 
 import {CodeCache} from '../../../src/modules/collector/CodeCache.js';
 import {CodeCompressor} from '../../../src/modules/collector/CodeCompressor.js';
@@ -17,6 +18,23 @@ interface MutableCodeCache {
 }
 
 describe('Code cache and compressor', () => {
+  it('resolves the default cache directory from the package root instead of process cwd', () => {
+    const originalCwd = process.cwd;
+    const fakeCwd = path.join(path.parse(process.cwd()).root, 'Windows', 'system32');
+
+    process.cwd = () => fakeCwd;
+
+    try {
+      const cache = new CodeCache();
+      const cacheDir = (cache as unknown as {cacheDir: string}).cacheDir;
+
+      assert.ok(cacheDir.endsWith(path.join('.cache', 'code')));
+      assert.ok(!cacheDir.startsWith(fakeCwd));
+    } finally {
+      process.cwd = originalCwd;
+    }
+  });
+
   it('stores and retrieves cache entries', async () => {
     const cache = new CodeCache({cacheDir: '/tmp/js-reverse-mcp-cache-test'});
     await cache.init();

--- a/tests/unit/modules/DebuggerManager.path.test.ts
+++ b/tests/unit/modules/DebuggerManager.path.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import {rm} from 'node:fs/promises';
+import path from 'node:path';
+import {describe, it} from 'node:test';
+
+import {DebuggerManager} from '../../../src/modules/debugger/DebuggerManager.js';
+import {resolveDefaultDebuggerSessionsDir} from '../../../src/utils/projectPaths.js';
+
+describe('DebuggerManager default session paths', () => {
+  it('saves and lists sessions under the package-root debugger-sessions directory', async () => {
+    const originalCwd = process.cwd;
+    const fakeCwd = path.join(path.parse(process.cwd()).root, 'Windows', 'system32');
+    const manager = new DebuggerManager({} as never);
+
+    process.cwd = () => fakeCwd;
+
+    let savedPath = '';
+    try {
+      savedPath = await manager.saveSession(undefined, {source: 'unit-test'});
+      const expectedRoot = resolveDefaultDebuggerSessionsDir(import.meta.url);
+
+      assert.ok(savedPath.startsWith(expectedRoot));
+      assert.ok(!savedPath.startsWith(fakeCwd));
+
+      const sessions = await manager.listSavedSessions();
+      assert.ok(sessions.some((session) => session.path === savedPath));
+    } finally {
+      process.cwd = originalCwd;
+      if (savedPath) {
+        await rm(savedPath, {force: true});
+      }
+    }
+  });
+});

--- a/tests/unit/utils/project-paths.test.ts
+++ b/tests/unit/utils/project-paths.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from 'node:assert';
+import path from 'node:path';
+import {describe, it} from 'node:test';
+
+import {
+  resolveDefaultCodeCacheDir,
+  resolveDefaultDebuggerSessionsDir,
+  resolveDefaultEnvPath,
+} from '../../../src/utils/projectPaths.js';
+
+describe('project path resolution', () => {
+  it('resolves runtime default paths from the package root instead of process cwd', () => {
+    const originalCwd = process.cwd;
+    const fakeCwd = path.join(path.parse(process.cwd()).root, 'Windows', 'system32');
+
+    process.cwd = () => fakeCwd;
+
+    try {
+      const codeCacheDir = resolveDefaultCodeCacheDir(import.meta.url);
+      const debuggerSessionsDir = resolveDefaultDebuggerSessionsDir(import.meta.url);
+      const envPath = resolveDefaultEnvPath(import.meta.url);
+
+      assert.ok(codeCacheDir.endsWith(path.join('.cache', 'code')));
+      assert.ok(debuggerSessionsDir.endsWith('debugger-sessions'));
+      assert.ok(envPath.endsWith('.env'));
+
+      assert.ok(!codeCacheDir.startsWith(fakeCwd));
+      assert.ok(!debuggerSessionsDir.startsWith(fakeCwd));
+      assert.ok(!envPath.startsWith(fakeCwd));
+    } finally {
+      process.cwd = originalCwd;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared runtime path resolver that anchors defaults to the nearest package root
- apply it to reverse task artifacts, debugger sessions, code cache, and `.env` loading
- add regression tests covering `system32` cwd drift on Windows-style launches

## Test Plan
- npm run build && node --require ./build/tests/setup.js --no-warnings=ExperimentalWarning --test build/tests/unit/utils/project-paths.test.js build/tests/unit/modules/DebuggerManager.path.test.js build/tests/unit/cache/CodeCacheCompressor.test.js build/tests/unit/reverse/ReverseTaskStore.test.js build/tests/unit/tools/rebuild.test.js build/tests/unit/utils/config.test.js build/tests/unit/tools/jshook-runtime.branches.test.js
